### PR TITLE
Multithread

### DIFF
--- a/anifetch.py
+++ b/anifetch.py
@@ -237,7 +237,7 @@ def get_sound():
 
 thread_sound = threading.Thread(target=get_sound)
 
-def chafa_process(f):
+def chafa_process(f, i):
     WIDTH = args.width
     HEIGHT = args.height
     # for i, f in enumerate(animation_files):
@@ -266,20 +266,15 @@ def chafa_process(f):
 
         # if wanted aspect ratio doesnt match source, chafa makes width as high as it can, and adjusts height accordingly.
         # AKA: even if I specify 40x20, chafa might give me 40x11 or something like that.
-    animation_files = os.listdir(BASE_PATH / "video")
-    chafa_files = os.listdir(BASE_PATH / "output")
-    if len(animation_files) == len(chafa_files): 
+    if i == 0: 
         HEIGHT = len(frame.splitlines())
         frames.append(frame) # dont question this, I need frames to have at least a single item
 
-def files_new():
-    animation_files = os.listdir(BASE_PATH / "video")
-    while len(animation_files) == 0:
-        animation_files = os.listdir(BASE_PATH / "video")
-    chafa_files = os.listdir(BASE_PATH / "output")
+def chafa_files():
     threads = []
+    animation_files = os.listdir(BASE_PATH / "video")
     for i, f in enumerate(animation_files):
-        thread_chafa = threading.Thread(target=chafa_process, args=(f, ))
+        thread_chafa = threading.Thread(target=chafa_process, args=(f, i, ))
 
         thread_chafa.start()
         threads.append(thread_chafa)
@@ -287,9 +282,6 @@ def files_new():
 
     for i in enumerate(threads):
         thread_chafa.join()
-
-thread_chafa = threading.Thread(target=files_new)
-
 
 # cache is invalid, re-render
 if should_update:
@@ -313,7 +305,7 @@ if should_update:
 
     thread_sound.join()
     
-    files_new()
+    chafa_files()
 
 
 


### PR DESCRIPTION
I added the threading to close: #9 

It probably could be a lot better, but it is implemented.
Here's the benchmark output info for my machine:
Threading:
```
ANIFETCH NOCACHE (Neofetch)
Caching...
It took 4.252040863037109 seconds.
Caching...
It took 4.289308786392212 seconds.
Caching...
It took 4.343307733535767 seconds.
Caching...
It took 4.245228052139282 seconds.
Caching...
It took 4.25253438949585 seconds.
Caching...
It took 4.265721082687378 seconds.
Caching...
It took 4.245808839797974 seconds.
Caching...
It took 4.287856340408325 seconds.
Caching...
It took 4.290659189224243 seconds.
Caching...
It took 4.221307039260864 seconds.
ANIFETCH CACHED (Neofetch)
It took 0.8123478889465332 seconds.
It took 0.8097891807556152 seconds.
It took 0.80167555809021 seconds.
It took 0.8192436695098877 seconds.
It took 0.8283965587615967 seconds.
It took 0.8217740058898926 seconds.
It took 0.814246654510498 seconds.
It took 0.8140480518341064 seconds.
It took 0.826866626739502 seconds.
It took 0.8288557529449463 seconds.
It took 0.8326723575592041 seconds.
ANIFETCH NOCACHE (Fastfetch)
Caching...
It took 3.53835129737854 seconds.
Caching...
It took 3.6349759101867676 seconds.
Caching...
It took 3.5685672760009766 seconds.
Caching...
It took 3.600893259048462 seconds.
Caching...
It took 3.5953798294067383 seconds.
Caching...
It took 3.685676097869873 seconds.
Caching...
It took 3.654515027999878 seconds.
Caching...
It took 3.6432554721832275 seconds.
Caching...
It took 3.588575601577759 seconds.
Caching...
It took 3.5591068267822266 seconds.
ANIFETCH CACHED (Fastfetch)
It took 0.11572027206420898 seconds.
It took 0.1129767894744873 seconds.
It took 0.10892343521118164 seconds.
It took 0.11934375762939453 seconds.
It took 0.11336588859558105 seconds.
It took 0.10922598838806152 seconds.
It took 0.11066150665283203 seconds.
It took 0.11399245262145996 seconds.
It took 0.11400175094604492 seconds.
It took 0.11601495742797852 seconds.
It took 0.11469292640686035 seconds.
Neofetch
9.228115320205688
Fastfetch
1.138763427734375
Anifetch(No Cache)(neofetch)
43.53014373779297
Anifetch(Cached)(neofetch)
8.540022850036621
Anifetch(No Cache)(fastfetch)
36.89965796470642
Anifetch(Cached)(fastfetch)
1.474745750427246
```
No threading:
```

ANIFETCH NOCACHE (Neofetch)
Caching...
It took 9.127363443374634 seconds.
Caching...
It took 9.068744897842407 seconds.
Caching...
It took 9.083215236663818 seconds.
Caching...
It took 8.991373538970947 seconds.
Caching...
It took 9.084569692611694 seconds.
Caching...
It took 9.035122871398926 seconds.
Caching...
It took 9.07432746887207 seconds.
Caching...
It took 9.095402002334595 seconds.
Caching...
It took 9.057516813278198 seconds.
Caching...
It took 9.248551368713379 seconds.
ANIFETCH CACHED (Neofetch)
It took 0.7868955135345459 seconds.
It took 0.8182957172393799 seconds.
It took 0.8180320262908936 seconds.
It took 0.7933425903320312 seconds.
It took 0.7964498996734619 seconds.
It took 0.7842671871185303 seconds.
It took 0.7907185554504395 seconds.
It took 0.7916460037231445 seconds.
It took 0.8200128078460693 seconds.
It took 0.7926642894744873 seconds.
It took 0.7995319366455078 seconds.
ANIFETCH NOCACHE (Fastfetch)
Caching...
It took 8.363066911697388 seconds.
Caching...
It took 8.444665431976318 seconds.
Caching...
It took 8.425288438796997 seconds.
Caching...
It took 8.39452314376831 seconds.
Caching...
It took 8.571038484573364 seconds.
Caching...
It took 8.549327850341797 seconds.
Caching...
It took 8.377037048339844 seconds.
Caching...
It took 8.519249200820923 seconds.
Caching...
It took 8.846063375473022 seconds.
Caching...
It took 8.81434154510498 seconds.
ANIFETCH CACHED (Fastfetch)
It took 0.11263847351074219 seconds.
It took 0.11906599998474121 seconds.
It took 0.11680197715759277 seconds.
It took 0.11721587181091309 seconds.
It took 0.1172788143157959 seconds.
It took 0.11991477012634277 seconds.
It took 0.11539649963378906 seconds.
It took 0.11403751373291016 seconds.
It took 0.1140604019165039 seconds.
It took 0.11395621299743652 seconds.
It took 0.12470054626464844 seconds.
Neofetch
9.1406090259552
Fastfetch
1.1368329524993896
Anifetch(No Cache)(neofetch)
91.65770888328552
Anifetch(Cached)(neofetch)
8.351279735565186
Anifetch(No Cache)(fastfetch)
86.14819645881653
Anifetch(Cached)(fastfetch)
1.5313568115234375
```

Every now and again benchmark.py gives an error on one of the runs to do with the png not being a valid file tho, most likely due to chafa trying to open an image before it can be rendered by ffmpeg. I've not had this issue once running the program normally though so idrk. Could probably fix it by adding a sleep command in somewhere to give ffmpeg more time to process the image before chafa tries to open it. I am tired tho lol so probably won't get that done today.