### PR TITLE
No filename needed

### DIFF
--- a/anifetch.py
+++ b/anifetch.py
@@ -73,11 +73,10 @@ parser.add_argument(
     action="store_true",
 )
 parser.add_argument(
-    "-f",
-    "--filename",
-    "--file",
-    required=True,
-    help="Specify a file via this argument.",
+    "filename",
+    nargs="?",  # <--filename> is optional
+    default=str(pathlib.Path.home() / "anifetch/example.mp4"),
+    help="Video file to use (default: ~/anifetch/example.mp4)",
     type=str,
 )
 parser.add_argument(


### PR DESCRIPTION
The default file is the `example.mp4` given, at the following position `~/anifetch/example.mp4`. You also don't need to add the `-f` as before, giving the video directly after calling anifetch.py works.