### PR TITLE
Fix lock showing on ghostty and other terminals that do that

### DIFF
--- a/src/anifetch/anifetch-static-resize2.sh
+++ b/src/anifetch/anifetch-static-resize2.sh
@@ -28,10 +28,14 @@ last_term_width=0
 
 # Hide cursor
 tput civis
+stty -icanon
+stty -echo
 
 # exit handler
 cleanup() {
   tput cnorm         # Show cursor
+	stty icanon
+	stty echo
   if [ -t 0 ]; then
     stty echo        # Restore echo
   fi

--- a/src/anifetch/anifetch-static-resize2.sh
+++ b/src/anifetch/anifetch-static-resize2.sh
@@ -28,23 +28,21 @@ last_term_width=0
 
 # Hide cursor
 tput civis
-stty -icanon
-stty -echo
 
 # exit handler
 cleanup() {
   tput cnorm         # Show cursor
-	stty icanon
-	stty echo
   if [ -t 0 ]; then
     stty echo        # Restore echo
   fi
   tput sgr0          # Reset terminal attributes
   tput cup $(tput lines) 0  # Move cursor to bottom
+	stty icanon
   exit 0
 }
 trap cleanup SIGINT SIGTERM
 stty -echo  # won't allow ^C to be printed when SIGINT signal comes.
+stty -icanon
 
 # Process the template once and store in memory buffer
 process_template() {


### PR DESCRIPTION
Basically noticed just now that when anifetch is run on ghostty and other terminals that display a lock when they think you are asking for password input, this lock appears and teleports across the render. I added stty -icanon and stty icanon to cleanup as I ran into this issue on my mpd album art script and these lines fixed it so it was a pretty simple fix on my end. LMK if stuff still works for you guys but I think it should. Again just a quick fix pr to something I noticed just now lol.