### PR TITLE
feat: add devShell to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,5 +24,32 @@
     overlays = import ./nix/overlays;
 
     formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.alejandra);
+
+    devShell = forAllSystems (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      myPython = pkgs.python3;
+      pythonWithPkgs = myPython.withPackages (ps: [
+        ps.pip
+        ps.setuptools
+      ]);
+      venv = "venv";
+    in
+      pkgs.mkShell {
+        packages = [
+          pythonWithPkgs
+          pkgs.bc
+          pkgs.chafa
+          pkgs.ffmpeg
+        ];
+
+        shellHook = ''
+          if [ ! -d "${venv}" ]; then
+            echo "Creating Python venv..."
+            python3 -m venv ${venv}
+          fi
+          echo "Activating venv..."
+          source ${venv}/bin/activate
+        '';
+      });
   };
 }


### PR DESCRIPTION
Includes a development shell with Python and common utilities.

- Sets up a Python virtual environment.
- Adds bc, chafa, and ffmpeg to packages.
- Automates venv creation and activation.

Just a lil thing for Nix devs that allows them to run nix develop and then pip install -e . to install anifetch in editable mode for development purposes.