### PR TITLE
Terminal Autostart Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ You can then run the `anifetch` command **directly in your terminal**.
 
 Since pipx installs packages in an isolated environment, you won't have to worry about dependency conflicts or polluting your global python environment. `anifetch` will behave just like a native cli tool. You can upgrade your installation with `pipx upgrade anifetch`
 
-
 ---
 
 ### 👨‍💻 Developer Installation (for contributors): via `pip` in a virtual environment
@@ -139,8 +138,7 @@ Currently only the `symbols` format of chafa is supported, formats like kitty, i
 
 ## Running Anifetch On Terminal Startup
 
-Add `exec anifetch [YOUR_FILENAME] [YOUR_ARGS] &` to the bottom of your `.bashrc`
-
+Add `anifetch [YOUR_FILENAME] [YOUR_ARGS]` to the bottom of your `.bashrc`
 
 ## 🚧 What's Next
 
@@ -166,7 +164,7 @@ Add `exec anifetch [YOUR_FILENAME] [YOUR_ARGS] &` to the bottom of your `.bashrc
 
 - [ ] Use threading when seperating video into frames and process them with chafa at the same time. This should speed up caching significantly.
 
-- [X] Fix transparent video frame seperation.
+- [x] Fix transparent video frame seperation.
 
 - [ ] Figure out a way to display animations faster. Either optimize the bash script or use Python/C.
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ If you set animation resolution really big it may not be able to keep up with th
 
 Currently only the `symbols` format of chafa is supported, formats like kitty, iterm etc. are not supported. If you try to tell chafa to use iterm, kitty etc. it will just override your format with `symbols` mode.
 
+## Running Anifetch On Terminal Startup
+
+Add `exec anifetch [YOUR_FILENAME] [YOUR_ARGS] &` to the bottom of your `.bashrc`
+
+
 ## 🚧 What's Next
 
 - [x] Add music support

--- a/README.md
+++ b/README.md
@@ -138,7 +138,16 @@ Currently only the `symbols` format of chafa is supported, formats like kitty, i
 
 ## Running Anifetch On Terminal Startup
 
-Add `anifetch [YOUR_FILENAME] [YOUR_ARGS]` to the bottom of your `.bashrc`
+Add this to the bottom of your `.bashrc` or `.zshrc`
+
+```sh
+# Only launch this program on direct terminal (tty) sessions
+if [[ -t 1 ]] && [[ $- == *i* ]]; then
+  anifetch [FILENAME] [ARGS]
+fi
+```
+
+also make sure PATH is available(for pipx installations) so it can find anifetch.
 
 ## 🚧 What's Next
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "anifetch"
-version = "0.1.1"
+version = "0.1.2"
 description = "Animated terminal fetch with video/audio support."
 authors = [{name = "Notenlish"}, {name = "Immelancholy"}, {name = "Gallophostrix", email = "gallophostrix@gmail.com"}]
 readme = "README.md"

--- a/src/anifetch/anifetch-static-resize2.sh
+++ b/src/anifetch/anifetch-static-resize2.sh
@@ -260,7 +260,6 @@ while true; do
     
     # if behind schedule
     if (( $(echo "$sleep_duration < 0" | bc -l) )); then
-        echo "skipping frame $i (behind by ${sleep_duration}s)" >> "$HOME/Desktop/anifetch-debug.log"
         i=$((i + 1))
         
         continue  # skip to the next frame.

--- a/src/anifetch/cli.py
+++ b/src/anifetch/cli.py
@@ -90,7 +90,7 @@ def parse_args():
         "-ff",
         "--fast-fetch",
         default=False,
-        help="Add this argument if you want to use fastfetch instead. Note than fastfetch will be run with '--logo none'.",
+        help="Add this argument if you want to use fastfetch instead of Neofetch.",
         action="store_true",
     )
     parser.add_argument(


### PR DESCRIPTION
I thought I'd just be done with adding the command to add to .bashrc and be done with it but no there is a slight bug with anifetch when its ran on terminal autostart. 

When terminal starts(no animation displayed yet), it gives this error:
```
stty: 'standard input': Inappropriate ioctl for device
stty: 'standard input': Inappropriate ioctly for device
```
after terminal has started playing the animation and I do ctrl c, it gives this:
stty: 'standard input': Inappropriate ioctly for device

this should be fixed with a startup flag spesifically for terminal autostarts.

Also maybe another flag for making the anifetch/neofetch output on top/bottom of the animation rather than to the side maybe? And another flag for potentially making the anifetch/neofetch output invisible maybe?