### PR TITLE
Key press exit 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Recommended Python version: 3.12 and later
 
 You need the following tools installed on your system:
 
+- `wtype` (if using wayland) or `xdotool` (if using x11)
+ - Debian/Ubuntu: `sudo apt install wtype` or `sudo apt install xdotool`
+ - Arch: `sudo pacman -S wtype` or `sudo pacman -S xdotool`
+
 - `bc`
 
   - Debian/Ubuntu: `sudo apt install bc`
@@ -163,11 +167,12 @@ Any video file you give to anifetch will be stored in `~/.local/share/anifetch/a
 ### Example usage:
 
 ```bash
-anifetch video.mp4 -r 10 -W 40 -H 20 -c "--symbols wide --fg-only"
+anifetch video.mp4 -k -r 10 -W 40 -H 20 -c "--symbols wide --fg-only"
 ```
 
 ### Optional arguments:
 
+- `-k` / `--key-exit`: exits `anifetch` on any keypress. The keypress will be logged in the terminal.
 - `-f` / `--file`: path to the video file (the path can be added without the `-f` argument)
 - `-s` / `--sound`: optional sound file to play alongside (requires `ffplay`)
 - `-r` / `--framerate`: frame rate of playback

--- a/README.md
+++ b/README.md
@@ -9,13 +9,6 @@ This is a small tool built with neofetch/fastfetch, ffmpeg and chafa. It allows 
 ### Prerequisites
 
 Recommended Python version: 3.12 and later
-
-You need the following tools installed on your system:
-
-- `wtype` (if using wayland) or `xdotool` (if using x11)
- - Debian/Ubuntu: `sudo apt install wtype` or `sudo apt install xdotool`
- - Arch: `sudo pacman -S wtype` or `sudo pacman -S xdotool`
-
 - `bc`
 
   - Debian/Ubuntu: `sudo apt install bc`

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ anifetch video.mp4 -k -r 10 -W 40 -H 20 -c "--symbols wide --fg-only"
 
 ### Optional arguments:
 
-- `-k` / `--key-exit`: exits `anifetch` on any keypress. The keypress will be logged in the terminal.
+- `-k` / `--key-exit`: exits `anifetch` on any keypress. 
 - `-f` / `--file`: path to the video file (the path can be added without the `-f` argument)
 - `-s` / `--sound`: optional sound file to play alongside (requires `ffplay`)
 - `-r` / `--framerate`: frame rate of playback

--- a/src/anifetch/anifetch-static-resize2.sh
+++ b/src/anifetch/anifetch-static-resize2.sh
@@ -52,7 +52,11 @@ cleanup() {
   
   # Echo the captured key in background after a delay (only if key-exit is enabled)
   if [ "$key_exit_enabled" = true ] && [ -n "$pressed_key" ]; then
-    wtype "$pressed_key"
+    if [ -n "$WAYLAND_DISPLAY" ]; then
+      wtype "$pressed_key"
+    elif [ -n "$DISPLAY" ]; then
+      xdotool type "$pressed_key"
+    fi
   fi
   
   exit 0

--- a/src/anifetch/anifetch-static-resize2.sh
+++ b/src/anifetch/anifetch-static-resize2.sh
@@ -46,7 +46,13 @@ cleanup() {
   
   # Echo the captured key in background after a delay
   if [ -n "$pressed_key" ]; then
-    (sleep 0.2 && printf "%s" "$pressed_key" | cat > /dev/tty) &
+    if command -v xdotool >/dev/null 2>&1; then
+      # Use xdotool to simulate actual keyboard input
+      (sleep 0.2 && xdotool type "$pressed_key") &
+    else
+      # Fallback: try to write to terminal input
+      (sleep 0.2 && printf "%s" "$pressed_key" > /dev/tty) &
+    fi
   fi
   
   exit 0

--- a/src/anifetch/anifetch-static-resize2.sh
+++ b/src/anifetch/anifetch-static-resize2.sh
@@ -41,15 +41,12 @@ cleanup() {
   fi
   tput sgr0          # Reset terminal attributes
   
-  cursor_pos=$((bottom + 1))
+  cursor_pos=$((bottom + 5))
   tput cup $cursor_pos 0
   
-  # Small delay to ensure terminal is ready before key echo
-  sleep 0.5
-  
-  # Echo the captured key
+  # Echo the captured key in background after a delay
   if [ -n "$pressed_key" ]; then
-    echo -n "$pressed_key"
+    (sleep 0.2 && echo -n "$pressed_key") &
   fi
   
   exit 0

--- a/src/anifetch/anifetch-static-resize2.sh
+++ b/src/anifetch/anifetch-static-resize2.sh
@@ -46,7 +46,7 @@ cleanup() {
   
   # Echo the captured key in background after a delay
   if [ -n "$pressed_key" ]; then
-    (sleep 0.2 && echo -n "$pressed_key") &
+    (sleep 0.2 && printf "%s" "$pressed_key" | cat > /dev/tty) &
   fi
   
   exit 0

--- a/src/anifetch/anifetch-static-resize2.sh
+++ b/src/anifetch/anifetch-static-resize2.sh
@@ -29,6 +29,9 @@ last_term_width=0
 # Hide cursor
 tput civis
 
+# Global variable to store the pressed key
+pressed_key=""
+
 # exit handler
 cleanup() {
   tput cnorm         # Show cursor
@@ -38,12 +41,21 @@ cleanup() {
   fi
   tput sgr0          # Reset terminal attributes
   
-  # Position cursor right under the neofetch output (bottom + 1)
-  cursor_pos=$((bottom + 1))
+  # Calculate total height: template lines + animation height
+  local template_height=${#template_buffer[@]}
+  local total_height=$((template_height + (bottom - top)))
+  
+  # Position cursor right under the entire output
+  cursor_pos=$((total_height + 1))
   tput cup $cursor_pos 0
   
   # Small delay to ensure terminal is ready before key echo
   sleep 0.1
+  
+  # Echo the captured key
+  if [ -n "$pressed_key" ]; then
+    echo -n "$pressed_key"
+  fi
   
   exit 0
 }
@@ -233,7 +245,7 @@ wanted_epoch=0
 start_time=$(date +%s.%N)
 while true; do
   # Check for any key press (non-blocking)
-  if read -t 0 -n 1; then
+  if read -t 0 -n 1 pressed_key; then
     cleanup
   fi
   
@@ -261,12 +273,12 @@ while true; do
     # Only sleep if ahead of schedule
     if (( $(echo "$sleep_duration > 0" | bc -l) )); then
         # Check for key press during sleep
-        if read -t "$sleep_duration" -n 1; then
+        if read -t "$sleep_duration" -n 1 pressed_key; then
             cleanup
         fi
     else
         # Check for key press (non-blocking)
-        if read -t 0 -n 1; then
+        if read -t 0 -n 1 pressed_key; then
             cleanup
         fi
     fi

--- a/src/anifetch/anifetch-static-resize2.sh
+++ b/src/anifetch/anifetch-static-resize2.sh
@@ -47,7 +47,7 @@ cleanup() {
   fi
   tput sgr0          # Reset terminal attributes
   
-  cursor_pos=20
+  cursor_pos=24
   tput cup $cursor_pos 0
   
   # Echo the captured key in background after a delay (only if key-exit is enabled)

--- a/src/anifetch/anifetch-static-resize2.sh
+++ b/src/anifetch/anifetch-static-resize2.sh
@@ -19,7 +19,7 @@ soundname=$7
 
 # Check if key-exit functionality is enabled
 key_exit_enabled=false
-if [[ $# -eq 8 && "$8" == "--key-exit" ]]; then
+if [[ "${!#}" == "--key-exit" ]]; then
   key_exit_enabled=true
 fi
 

--- a/src/anifetch/anifetch-static-resize2.sh
+++ b/src/anifetch/anifetch-static-resize2.sh
@@ -46,13 +46,7 @@ cleanup() {
   
   # Echo the captured key in background after a delay
   if [ -n "$pressed_key" ]; then
-    if command -v xdotool >/dev/null 2>&1; then
-      # Use xdotool to simulate actual keyboard input
-      (sleep 0.2 && xdotool type "$pressed_key") &
-    else
-      # Fallback: try to write to terminal input
-      (sleep 0.2 && printf "%s" "$pressed_key" > /dev/tty) &
-    fi
+    wtype "$pressed_key"
   fi
   
   exit 0

--- a/src/anifetch/anifetch-static-resize2.sh
+++ b/src/anifetch/anifetch-static-resize2.sh
@@ -243,10 +243,8 @@ wanted_epoch=0
 start_time=$(date +%s.%N)
 while true; do
   # Check for any key press (non-blocking) - only if key-exit is enabled
-  if [ "$key_exit_enabled" = true ]; then
-    if read -t 0 -n 1 pressed_key; then
-      cleanup
-    fi
+  if read -t 0 -n 1 pressed_key && [ "$key_exit_enabled" = true ]; then
+    cleanup
   fi
   
   for frame in $(ls "$FRAME_DIR" | sort -n); do

--- a/src/anifetch/anifetch-static-resize2.sh
+++ b/src/anifetch/anifetch-static-resize2.sh
@@ -47,7 +47,7 @@ cleanup() {
   fi
   tput sgr0          # Reset terminal attributes
   
-  cursor_pos=24
+  cursor_pos=25
   tput cup $cursor_pos 0
   
   # Echo the captured key in background after a delay (only if key-exit is enabled)

--- a/src/anifetch/anifetch-static-resize2.sh
+++ b/src/anifetch/anifetch-static-resize2.sh
@@ -41,16 +41,11 @@ cleanup() {
   fi
   tput sgr0          # Reset terminal attributes
   
-  # Calculate total height: template lines + animation height
-  local template_height=${#template_buffer[@]}
-  local total_height=$((template_height + (bottom - top)))
-  
-  # Position cursor right under the entire output
-  cursor_pos=$((total_height + 1))
+  cursor_pos=$((bottom + 1))
   tput cup $cursor_pos 0
   
   # Small delay to ensure terminal is ready before key echo
-  sleep 0.1
+  sleep 0.5
   
   # Echo the captured key
   if [ -n "$pressed_key" ]; then

--- a/src/anifetch/anifetch-static-resize2.sh
+++ b/src/anifetch/anifetch-static-resize2.sh
@@ -47,7 +47,7 @@ cleanup() {
   fi
   tput sgr0          # Reset terminal attributes
   
-  cursor_pos=$((bottom + 10))
+  cursor_pos=20
   tput cup $cursor_pos 0
   
   # Echo the captured key in background after a delay (only if key-exit is enabled)

--- a/src/anifetch/anifetch-static-resize2.sh
+++ b/src/anifetch/anifetch-static-resize2.sh
@@ -15,7 +15,10 @@ left=$3
 right=$4
 bottom=$5
 template_actual_width=$6
-soundname=$7
+soundname=""
+if [ $# -ge 7 ] && [ "${7}" != "--key-exit" ]; then
+  soundname=$7
+fi
 
 # Check if key-exit functionality is enabled
 key_exit_enabled=false
@@ -46,18 +49,7 @@ cleanup() {
     stty icanon
   fi
   tput sgr0          # Reset terminal attributes
-  
-  cursor_pos=30
-  tput cup $cursor_pos 0
-  
-  # Echo the captured key in background after a delay (only if key-exit is enabled)
-  if [ "$key_exit_enabled" = true ] && [ -n "$pressed_key" ]; then
-    if [ -n "$WAYLAND_DISPLAY" ]; then
-      wtype "$pressed_key"
-    elif [ -n "$DISPLAY" ]; then
-      xdotool type "$pressed_key"
-    fi
-  fi
+  tput cup $(tput lines) 0 # Move cursor to bottom
   
   exit 0
 }
@@ -238,7 +230,7 @@ trap 'on_resize' SIGWINCH
 draw_static_template
 
 # Start audio if sound is provided
-if [ $# -eq 7 ]; then
+if [ -n "$soundname" ]; then
   ffplay -nodisp -autoexit -loop 0 -loglevel quiet "$soundname" &
 fi
 

--- a/src/anifetch/anifetch-static-resize2.sh
+++ b/src/anifetch/anifetch-static-resize2.sh
@@ -47,7 +47,7 @@ cleanup() {
   fi
   tput sgr0          # Reset terminal attributes
   
-  cursor_pos=$((bottom + 5))
+  cursor_pos=$((bottom + 10))
   tput cup $cursor_pos 0
   
   # Echo the captured key in background after a delay (only if key-exit is enabled)

--- a/src/anifetch/anifetch-static-resize2.sh
+++ b/src/anifetch/anifetch-static-resize2.sh
@@ -34,10 +34,17 @@ cleanup() {
   tput cnorm         # Show cursor
   if [ -t 0 ]; then
     stty echo        # Restore echo
-		stty icanon
+    stty icanon
   fi
   tput sgr0          # Reset terminal attributes
-  tput cup $(tput lines) 0  # Move cursor to bottom
+  
+  # Position cursor right under the neofetch output (bottom + 1)
+  cursor_pos=$((bottom + 1))
+  tput cup $cursor_pos 0
+  
+  # Small delay to ensure terminal is ready before key echo
+  sleep 0.1
+  
   exit 0
 }
 trap cleanup SIGINT SIGTERM

--- a/src/anifetch/anifetch-static-resize2.sh
+++ b/src/anifetch/anifetch-static-resize2.sh
@@ -225,6 +225,10 @@ i=1
 wanted_epoch=0
 start_time=$(date +%s.%N)
 while true; do
+  # Check for any key press (non-blocking)
+  if read -t 0 -n 1; then
+    cleanup
+  fi
   
   for frame in $(ls "$FRAME_DIR" | sort -n); do
     lock=true
@@ -249,7 +253,15 @@ while true; do
 
     # Only sleep if ahead of schedule
     if (( $(echo "$sleep_duration > 0" | bc -l) )); then
-        sleep "$sleep_duration"
+        # Check for key press during sleep
+        if read -t "$sleep_duration" -n 1; then
+            cleanup
+        fi
+    else
+        # Check for key press (non-blocking)
+        if read -t 0 -n 1; then
+            cleanup
+        fi
     fi
 
     i=$((i + 1))

--- a/src/anifetch/anifetch-static-resize2.sh
+++ b/src/anifetch/anifetch-static-resize2.sh
@@ -47,7 +47,7 @@ cleanup() {
   fi
   tput sgr0          # Reset terminal attributes
   
-  cursor_pos=25
+  cursor_pos=30
   tput cup $cursor_pos 0
   
   # Echo the captured key in background after a delay (only if key-exit is enabled)

--- a/src/anifetch/cli.py
+++ b/src/anifetch/cli.py
@@ -105,6 +105,13 @@ def parse_args():
         action="version",
         version="%(prog)s {version}".format(version=get_version_of_anifetch()),
     )
+    parser.add_argument(
+        "-k",
+        "--key-exit",
+        default=False,
+        action="store_true",
+        help="Enable key press to exit functionality. When enabled, pressing any key will exit the animation and echo the key to the terminal.",
+    )
 
     args = parser.parse_args()
 

--- a/src/anifetch/core.py
+++ b/src/anifetch/core.py
@@ -392,6 +392,8 @@ def run_anifetch(args):
             ]
             if args.sound_flag_given:  # if user requested for sound to be played
                 script_args.append(str(args.sound_saved_path))
+            if args.key_exit:  # if user requested key exit functionality
+                script_args.append("--key-exit")
 
             print_verbose(args.verbose, script_args)
             # raise SystemExit


### PR DESCRIPTION
- **Added `-k` flag:** Enables exit upon any keypress. The key which is pressed is then passed to the terminal being used. This makes it much more pleasant to use `anifetch` on terminal startup. 

- On Wayland systems (like my own setup), such as those using Hyprland, `wtype` is used to pass the keypress to the terminal. On X11 systems, `xdotool` is used. **Note that this functionality has not been tested on X11.**

- Updated the README to reflect these changes.

- I have changed the cursor repositioning to the end of the `anifetch` output. In my case, the cursor was being placed at the bottom of my terminal. This is more desirable on my system, but I note it here as the change is unrelated to the core feature.

I hope others find this feature useful!