### PR TITLE
FIX: fix dependencies, typo, and binary naming mismatch

### DIFF
--- a/nix/packages/anifetch.nix
+++ b/nix/packages/anifetch.nix
@@ -9,7 +9,7 @@
 in
   fs.trace sourceFiles
   python3Packages.buildPythonApplication {
-    name = "anifetch";
+    name = "anifetch-wrapped";
     version = "1.0.0";
     pyproject = true;
     src = fs.toSource {
@@ -33,6 +33,7 @@ in
     meta = with lib; {
       description = "neofetch but animated ";
       homepage = "https://github.com/tickreyiz/anifetch";
+      mainProgram = "anifetch";
       license = licenses.mit;
       maintainers = with maintainers; [Immelancholy];
     };

--- a/nix/packages/anifetch.nix
+++ b/nix/packages/anifetch.nix
@@ -9,7 +9,7 @@
 in
   fs.trace sourceFiles
   python3Packages.buildPythonApplication {
-    name = "aniftech-wrapped";
+    name = "anifetch-wrapped";
     version = "1.0.0";
     pyproject = true;
     src = fs.toSource {

--- a/nix/packages/anifetch.nix
+++ b/nix/packages/anifetch.nix
@@ -9,7 +9,7 @@
 in
   fs.trace sourceFiles
   python3Packages.buildPythonApplication {
-    name = "anifetch-wrapped";
+    name = "anifetch";
     version = "1.0.0";
     pyproject = true;
     src = fs.toSource {
@@ -32,7 +32,7 @@ in
 
     meta = with lib; {
       description = "neofetch but animated ";
-      homepage = "https://github.com/Notenlish/anifetch";
+      homepage = "https://github.com/tickreyiz/anifetch";
       license = licenses.mit;
       maintainers = with maintainers; [Immelancholy];
     };

--- a/nix/packages/anifetch.nix
+++ b/nix/packages/anifetch.nix
@@ -25,6 +25,9 @@ in
       pkgs.chafa
       pkgs.ffmpeg
       pkgs.python3Packages.platformdirs
+      pkgs.python3Packages.pynput
+      pkgs.python3Packages.rich
+      pkgs.python3Packages.wcwidth
     ];
 
     meta = with lib; {


### PR DESCRIPTION
Fixes multiple issues preventing the Nix package from building and running successfully:

-Missing Dependencies: Added missing Python runtime dependencies (pynput, rich, wcwidth).

-Typo Fix: Corrected the aniftech spelling error to line up with the repository naming convention.

-Binary Mismatch: Handled the buildPythonApplication wrapper mismatch by matching the binary specification using meta.mainProgram.