### PR TITLE
Add pre-commit hook for nix users that does auto formatting + check with ruff and other improvements.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,3 @@
+watch_dir src
+
 use flake

--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,3 @@
-watch_dir src
-
 watch_dir nix
 
 use flake

--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,5 @@
 watch_dir src
 
+watch_dir nix
+
 use flake

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .flatpak-builder/
 .ignore/
 .direnv/
+/.pre-commit-config.yaml
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/flake.lock
+++ b/flake.lock
@@ -1,6 +1,79 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1770073757,
+        "narHash": "sha256-Vy+G+F+3E/Tl+GMNgiHl9Pah2DgShmIUBJXmbiQPHbI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "47472570b1e607482890801aeaf29bfb749884f6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1780243769,
         "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
@@ -18,7 +91,8 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "git-hooks": "git-hooks",
+        "nixpkgs": "nixpkgs_2"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -54,19 +54,27 @@
         pkgs.writeShellScriptBin "pre-commit-run" script
       );
 
-      checks = forAllSystems (system: {
-        pre-commit-check = inputs.git-hooks.lib.${system}.run {
-          src = ./.;
-          hooks = {
-            nixfmt.enable = true;
+      checks = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          pre-commit-check = inputs.git-hooks.lib.${system}.run {
+            src = ./.;
+            hooks = {
+              nixfmt.enable = true;
 
-            ruff-sh = {
-              enable = true;
-              entry = "./ruff.sh";
+              ruff-sh = {
+                enable = true;
+                entry = "./ruff.sh";
+              };
             };
+
+            package = pkgs.prek;
           };
-        };
-      });
+        }
+      );
 
       devShell = forAllSystems (
         system:

--- a/flake.nix
+++ b/flake.nix
@@ -99,15 +99,38 @@
         system:
         let
           pkgs = import nixpkgs { inherit system; };
+          myPython = pkgs.python3;
+          pythonWithPkgs = myPython.withPackages (ps: [
+            ps.pip
+            ps.setuptools
+          ]);
+
+          venv = "venv";
           inherit (self.checks.${system}.pre-commit-check) shellHook enabledPackages;
         in
         {
           default = pkgs.mkShell {
-            inherit shellHook;
             nativeBuildInputs = [
-              self.packages.${system}.default
+              pythonWithPkgs
+              pkgs.bc
+              pkgs.chafa
+              pkgs.ffmpeg
             ]
             ++ enabledPackages;
+            shellHook = shellHook + ''
+              export "CPATH=${pkgs.linuxHeaders}/include:$CPATH"
+              if [ ! -d "${venv}" ]; then
+                echo "Creating Python venv..."
+                python3 -m venv ${venv}
+              fi
+              echo "Activating venv..."
+              source ${venv}/bin/activate
+              if ! pip show anifetch &>/dev/null; then
+                echo "Aniftech not installed: Install anifetch..."
+                pip install -e .
+              fi
+              echo "Venv activated."
+            '';
           };
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    git-hooks.url = "github:cachix/git-hooks.nix";
   };
 
   outputs =
@@ -12,6 +13,7 @@
       ...
     }:
     let
+      inherit (self) inputs;
       systems = [
         "x86_64-linux"
         "aarch64-linux"
@@ -39,15 +41,45 @@
         anifetch = self.overlays.default;
       };
 
-      formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-tree);
+      formatter = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          config = self.checks.${system}.pre-commit-check.config;
+          inherit (config) package configFile;
+          script = ''
+            ${pkgs.lib.getExe package} run --all-files --config ${configFile}
+          '';
+        in
+        pkgs.writeShellScriptBin "pre-commit-run" script
+      );
+
+      checks = forAllSystems (system: {
+        pre-commit-check = inputs.git-hooks.lib.${system}.run {
+          src = ./.;
+          hooks = {
+            nixfmt.enable = true;
+
+            ruff-sh = {
+              enable = true;
+              entry = "./ruff.sh";
+            };
+          };
+        };
+      });
 
       devShell = forAllSystems (
         system:
         let
           pkgs = import nixpkgs { inherit system; };
+          inherit (self.checks.${system}.pre-commit-check) shellHook enabledPackages;
         in
         pkgs.mkShell {
-          packages = [
+          inherit shellHook;
+          buildInputs = enabledPackages;
+          packages = with pkgs; [
+            bash
+            ruff
             self.packages.${pkgs.stdenv.hostPlatform.system}.default
           ];
         }

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
         in
         {
           default = pkgs.callPackage ./nix/package.nix { };
-          anifetch = self.packages.default;
+          anifetch = self.packages.${system}.default;
         }
       );
 
@@ -65,9 +65,28 @@
             hooks = {
               nixfmt.enable = true;
 
-              ruff-sh = {
+              ruff-check = {
                 enable = true;
-                entry = "./ruff.sh";
+                entry = "${pkgs.lib.getExe pkgs.ruff}";
+                args = [
+                  "check"
+                  "--fix"
+                ];
+                types = [
+                  "file"
+                  "python"
+                ];
+              };
+              ruff-format = {
+                enable = true;
+                entry = "${pkgs.lib.getExe pkgs.ruff}";
+                args = [
+                  "format"
+                ];
+                types = [
+                  "file"
+                  "python"
+                ];
               };
             };
 
@@ -76,20 +95,20 @@
         }
       );
 
-      devShell = forAllSystems (
+      devShells = forAllSystems (
         system:
         let
           pkgs = import nixpkgs { inherit system; };
           inherit (self.checks.${system}.pre-commit-check) shellHook enabledPackages;
         in
-        pkgs.mkShell {
-          inherit shellHook;
-          buildInputs = enabledPackages;
-          packages = with pkgs; [
-            bash
-            ruff
-            self.packages.${pkgs.stdenv.hostPlatform.system}.default
-          ];
+        {
+          default = pkgs.mkShell {
+            inherit shellHook;
+            nativeBuildInputs = [
+              self.packages.${system}.default
+            ]
+            ++ enabledPackages;
+          };
         }
       );
     };

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -8,10 +8,11 @@
 let
   fs = lib.fileset;
   sourceFiles = ../.;
+  anifetchPyprojectToml = fromTOML (builtins.readFile ../pyproject.toml);
 in
 fs.trace sourceFiles python3Packages.buildPythonApplication {
-  name = "anifetch-wrapped";
-  version = "git";
+  pname = "anifetch";
+  version = "${anifetchPyprojectToml.project.version}-git";
   pyproject = true;
   src = fs.toSource {
     root = ../.;

--- a/ruff.sh
+++ b/ruff.sh
@@ -2,4 +2,3 @@
 
 ruff check . --fix
 ruff format .
-

--- a/ruff.sh
+++ b/ruff.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ruff check . --fix
 ruff format .
+


### PR DESCRIPTION
Another pr lol. Further this should help with nix users to format code up to standard and also run the ruff.sh script as well! I had to modify it to use 
`#!/usr/bin/env bash` though, which I believe is best practice for scripts anyway as not everyone has bash installed in `/bin/bash`, but I think env is univeral across unix systems I believe.

Only thing with this is I'm not sure what would need to be done if you wanted to use AND have a separate pre-commit. Could add a generator for the yaml file ig. Although I can't see we use pre-commit on this without nix anyway.