### PR TITLE
Pyproject: Use >= to allow better version compat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,10 +37,10 @@
     license = { text = "MIT" }
     requires-python = ">=3.11"
     dependencies = [
-        "platformdirs==4.5.1",
-        "wcwidth==0.2.14",
-        "rich==14.3.1",
-        "pynput==1.8.1",
+        "platformdirs>=4.5.1",
+        "wcwidth>=0.2.14",
+        "rich>=14.3.1",
+        "pynput>=1.8.1",
         # "regex==2026.5.9"
     ]
 


### PR DESCRIPTION
Nix broke cos the python packages are too new compared to anifetch's I imagine this could happen with Arch as well as they have the same kinda thing with packaged python deps. This should fix that. :>